### PR TITLE
add operstor homework

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Done
 Кажется, что к хелму не установлен плагин для пуша чарта. В методичке опять пропущены важные шаги.
 Пойдём другим путём.
 
-Далаем пакеды из фронта и основного прилождения
+Далаем пакеты из фронта и основного прилождения
 
 helm package .
 получаем tgz
@@ -378,3 +378,55 @@ Done
 Лениво писать. Накопипастил. Вроде завелось.
 
 
+# Выполнено ДЗ №7
+7.1 Подготовка
+Данное ДЗ выполнялось на кластере получившемся в результате выполнения задания №6
+
+7.2 Useless CR
+Done
+
+7.3 Создание CRD
+Интересно, материал из методички вообще хоть кто-то проверял хоть раз?
+По ссылке https://gist.githubusercontent.com/Evgenikk/581fa5bba6d924a3438be1e3d31aa468/raw/417c044e203f378b90ff94eb0103df3f143427b2/bacis_crd.yml
+Лежит кривой файл, который не устанавливается хотябы потому, что указано apiVersion: apiextensions.k8s.io/v1beta1, а не apiVersion: apiextensions.k8s.io/v1
+Что приводит к ошибке - error: resource mapping not found for name: "mysqls.otus.homework" namespace: "" from "./bacis_crd_old.yml": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"
+
+Исправление первой ошибки приводит ко второй - The CustomResourceDefinition "mysqls.otus.homework" is invalid: spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required
+
+Опять масса потраченного зра времени...
+
+7.4 Добавить проверку полей
+Done
+
+7.5 Подготовка контроллера
+Копирование темплейтов, копипаст кода, запуск - облом.
+
+Надо доставить через pip кроме самого kopf ещё модули kubernetes и jinja2
+
+Что-то запустилось. Висит. По логам не создаются PVC
+Гуглим. Ошибка в темплейтах, создающих PVC.
+с local-path несовместимо такое использование секции selector:
+    matchLabels:
+      pv-usage: "backup-{{ name }}"
+Удаляем.
+
+Делаем докер-образ.
+
+
+7.6 Деплой оператора
+Правим название контейнера.
+Деплоим. Все PV и PVC есть сервисы задеплоились
+
+7.7 Заполняем данными и проверям
+kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
+mysql: [Warning] Using a password on the command line interface can be insecure.
++----+-------------+
+| id | name        |
++----+-------------+
+|  1 | some data   |
+|  2 | some data-2 |
++----+-------------+
+
+7.8 Удалить mysql-instance
+Удалилась и перезапустилась.
+База без изменений

--- a/kubernetes-operators/build/Dockerfile
+++ b/kubernetes-operators/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7
+COPY templates ./templates
+COPY mysql-operator.py ./mysql-operator.py
+RUN pip install kopf kubernetes pyyaml jinja2
+CMD kopf run /mysql-operator.py

--- a/kubernetes-operators/build/build-and-push.sh
+++ b/kubernetes-operators/build/build-and-push.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build . -t vpol4mail/otus-2023-10-mysql-operator:0.3
+docker push vpol4mail/otus-2023-10-mysql-operator:0.3

--- a/kubernetes-operators/build/controller-1.py
+++ b/kubernetes-operators/build/controller-1.py
@@ -1,0 +1,50 @@
+import kopf
+import yaml
+import kubernetes
+import time
+from jinja2 import Environment, FileSystemLoader
+
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.load(yaml_manifest)
+    return json_manifest
+
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+# Функция, которая будет запускаться при создании объектов тип MySQL:
+def mysql_on_create(body, spec, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    storage_size = body['spec']['storage_size']
+
+    # Генерируем JSON манифесты для деплоя
+    persistent_volume = render_template('mysql-pv.yml.j2',
+                                        {'name': name,
+                                         'storage_size': storage_size})
+    persistent_volume_claim = render_template('mysql-pvc.yml.j2',
+                                              {'name': name,
+                                               'storage_size': storage_size})
+    service = render_template('mysql-service.yml.j2', {'name': name})
+
+    deployment = render_template('mysql-deployment.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+
+    api = kubernetes.client.CoreV1Api()
+    # Создаем mysql PV:
+    api.create_persistent_volume(persistent_volume)
+    # Создаем mysql PVC:
+    api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    # Создаем mysql SVC:
+    api.create_namespaced_service('default', service)
+
+    # Создаем mysql Deployment:
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)

--- a/kubernetes-operators/build/mysql-operator.py
+++ b/kubernetes-operators/build/mysql-operator.py
@@ -1,0 +1,112 @@
+import kopf
+import yaml
+import kubernetes
+import time
+from jinja2 import Environment, FileSystemLoader
+
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.safe_load(yaml_manifest)
+    return json_manifest
+
+
+def delete_success_jobs(mysql_instance_name):
+    api = kubernetes.client.BatchV1Api()
+    jobs = api.list_namespaced_job('default')
+    for job in jobs.items:
+        jobname = job.metadata.name
+        if jobname == f"backup-{mysql_instance_name}-job":
+            if job.status.succeeded == 1:
+                api.delete_namespaced_job(jobname, 'default', propagation_policy='Background')
+
+
+def wait_until_job_end(jobname):
+    api = kubernetes.client.BatchV1Api()
+    job_finished = False
+    jobs = api.list_namespaced_job('default')
+    while (not job_finished) and any(job.metadata.name == jobname for job in jobs.items):
+        time.sleep(1)
+        jobs = api.list_namespaced_job('default')
+        for job in jobs.items:
+            if job.metadata.name == jobname:
+                if job.status.succeeded == 1:
+                    job_finished = True
+
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+# Функция, которая будет запускаться при создании объектов тип MySQL:
+def mysql_on_create(body, spec, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']  # cохраняем в переменные содержимое описания MySQL из CR
+    password = body['spec']['password']
+    database = body['spec']['database']
+    storage_size = body['spec']['storage_size']
+
+    # Генерируем JSON манифесты для деплоя
+    persistent_volume = render_template('mysql-pv.yml.j2', {'name': name, 'storage_size': storage_size})
+    persistent_volume_claim = render_template('mysql-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
+    service = render_template('mysql-service.yml.j2', {'name': name})
+    deployment = render_template('mysql-deployment.yml.j2', {'name': name, 'image': image, 'password': password, 'database': database})
+    restore_job = render_template('restore-job.yml.j2', {'name': name, 'image': image, 'password': password, 'database': database})
+
+    # Определяем, что созданные ресурсы являются дочерними к управляемому CustomResource:
+    kopf.append_owner_reference(persistent_volume, owner=body)
+    kopf.append_owner_reference(persistent_volume_claim, owner=body)  # addopt
+    kopf.append_owner_reference(service, owner=body)
+    kopf.append_owner_reference(deployment, owner=body)
+    kopf.append_owner_reference(restore_job, owner=body)
+    # ^ Таким образом при удалении CR удалятся все, связанные с ним pv,pvc,svc, deployments
+
+    api = kubernetes.client.CoreV1Api()
+    # Создаем mysql PV:
+    api.create_persistent_volume(persistent_volume)
+    # Создаем mysql PVC:
+    api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    # Создаем mysql SVC:
+    api.create_namespaced_service('default', service)
+    # Создаем mysql Deployment:
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)
+
+    # Cоздаем PVC и PV для бэкапов:
+    try:
+        backup_pv = render_template('backup-pv.yml.j2', {'name': name})
+        api = kubernetes.client.CoreV1Api()
+        api.create_persistent_volume(backup_pv)
+    except kubernetes.client.rest.ApiException:
+        pass
+    try:
+        backup_pvc = render_template('backup-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
+        api = kubernetes.client.CoreV1Api()
+        api.create_namespaced_persistent_volume_claim('default', backup_pvc)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    # Пытаемся восстановиться из backup
+    try:
+        api = kubernetes.client.BatchV1Api()
+        api.create_namespaced_job('default', restore_job)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_object_make_backup(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']  # cохраняем в переменные содержимое описания MySQL из CR
+    password = body['spec']['password']
+    database = body['spec']['database']
+
+    delete_success_jobs(name)
+
+    # Cоздаем backup job:
+    api = kubernetes.client.BatchV1Api()
+    backup_job = render_template('backup-job.yml.j2', {'name': name, 'image': image, 'password': password, 'database': database})
+    api.create_namespaced_job('default', backup_job)
+    wait_until_job_end(f"backup-{name}-job")
+    api = kubernetes.client.CoreV1Api()
+    api.delete_persistent_volume(f"{name}-pv")
+
+    return {'message': "mysql and its children resources deleted"}

--- a/kubernetes-operators/build/templates/backup-job.yml.j2
+++ b/kubernetes-operators/build/templates/backup-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: backup-{{ name }}-job
+  labels:
+    usage: backup-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: backup-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysqldump -u root -h {{ name }} -p{{ password }} {{ database }}  > /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/backup-pv.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:  "backup-{{ name }}-pv"
+  labels:
+    pv-usage: "backup-{{ name }}"
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /data/pv-backup/

--- a/kubernetes-operators/build/templates/backup-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "backup-{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-deployment.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-deployment.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+      - image: {{ image }}
+        name: {{ name }}
+        args:
+        - "--ignore-db-dir=lost+found"
+        env:
+        - name: MYSQL_ROOT_PASSWORD # так делать не нужно, тут лучше secret
+          value: {{ password }}
+        - name: MYSQL_DATABASE
+          value: {{ database }}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: {{ name }}-pv
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: {{ name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ name }}-pvc

--- a/kubernetes-operators/build/templates/mysql-pv.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ name }}-pv
+  labels:
+    pv-usage: {{ name }}
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}
+  hostPath:
+    path: /data/{{ name }}-pv/

--- a/kubernetes-operators/build/templates/mysql-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-service.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-service.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: {{ name }}
+  clusterIP: None

--- a/kubernetes-operators/build/templates/restore-job.yml.j2
+++ b/kubernetes-operators/build/templates/restore-job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: restore-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: restore-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup
+        image: mysql:5.7
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ password }} {{ database }}< /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/deploy/bacis_crd.yaml
+++ b/kubernetes-operators/deploy/bacis_crd.yaml
@@ -1,0 +1,18 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+   name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+   scope: Namespaced     # Данный CRD будер работать в рамках namespace
+   group: otus.homework  # Группа, отражается в поле apiVersion CR
+   versions:             # Список версий
+       - name: v1
+         served: true      # Будет ли обслуживаться API-сервером данная версия
+         storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+   names:                # различные форматы имени объекта CR
+       kind: MySQL         # kind CR
+       plural: mysqls
+       singular: mysql
+       shortNames:
+         - ms
+

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,10 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword  # Так делать не нужно, следует использовать secret
+  storage_size: 1Gi
+

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  scope: Namespaced
+  group: otus.homework
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+            spec:
+              type: object
+              properties:
+                image: 
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+              required:
+                - image
+                - database
+                - password
+                - storage_size 
+  names:
+    kind: MySQL
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "vpol4mail/otus-2023-10-mysql-operator:0.3"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+  - kind: ServiceAccount
+    name: mysql-operator
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ №7
7.1 Подготовка
Данное ДЗ выполнялось на кластере получившемся в результате выполнения задания №6

7.2 Useless CR
Done

7.3 Создание CRD
Интересно, материал из методички вообще хоть кто-то проверял хоть раз?
По ссылке https://gist.githubusercontent.com/Evgenikk/581fa5bba6d924a3438be1e3d31aa468/raw/417c044e203f378b90ff94eb0103df3f143427b2/bacis_crd.yml
Лежит кривой файл, который не устанавливается хотябы потому, что указано apiVersion: apiextensions.k8s.io/v1beta1, а не apiVersion: apiextensions.k8s.io/v1
Что приводит к ошибке - error: resource mapping not found for name: "mysqls.otus.homework" namespace: "" from "./bacis_crd_old.yml": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"

Исправление первой ошибки приводит ко второй - The CustomResourceDefinition "mysqls.otus.homework" is invalid: spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required

Опять масса потраченного зра времени...

7.4 Добавить проверку полей
Done

7.5 Подготовка контроллера
Копирование темплейтов, копипаст кода, запуск - облом.

Надо доставить через pip кроме самого kopf ещё модули kubernetes и jinja2

Что-то запустилось. Висит. По логам не создаются PVC
Гуглим. Ошибка в темплейтах, создающих PVC.
с local-path несовместимо такое использование секции selector:
    matchLabels:
      pv-usage: "backup-{{ name }}"
Удаляем.

Делаем докер-образ.


7.6 Деплой оператора
Правим название контейнера.
Деплоим. Все PV и PVC есть сервисы задеплоились

7.7 Заполняем данными и проверям
kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
mysql: [Warning] Using a password on the command line interface can be insecure.
+----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
+----+-------------+

7.8 Удалить mysql-instance
Удалилась и перезапустилась.
База без изменений
